### PR TITLE
Add 19.0.0 support, update README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Build libnx
         run: |
-          git clone https://github.com/Atmosphere-NX/libnx.git --branch 1600_support /tmp/libnx
+          git clone https://github.com/Atmosphere-NX/libnx.git --branch 1900_support /tmp/libnx
           pushd /tmp/libnx
           make PREFIX="ccache aarch64-none-elf-"
           make install

--- a/README.md
+++ b/README.md
@@ -8,6 +8,23 @@ network_mitm allows you to:
 
 More features might appears depending of the needs.
 
+## Configuration
+The following configuration should go in `/atmosphere/config/system_settings.ini`:
+
+```ini
+; network_mitm config
+[network_mitm]
+; Enable SSL: This should be set to 1 for certificate swapping, and also for PCAP capturing.
+enable_ssl = u8!0x1
+; Root CA filename: this should be present in the root of the SD (sd:/rootCA.pem for the below example)
+custom_ca_public_cert = str!rootCA.pem
+; By default, the sysmodule will dump decrypted network traffic user-link PCAPs to the SD card.
+; Uncomment this line to disable.
+; should_dump_ssl_traffic = u8!0x0
+; Possible values "ethernet", "ip" or "user"
+; pcap_link_type = str!user
+```
+
 ## Building
 
 Make sure that the submodules are initialized and up to date.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # network_mitm
 
-Nintendo Switch Network mitm sysmodule.
+Nintendo Switch Network MITM sysmodule.
 
 network_mitm allows you to:
 - Dump traffic from SSL of the running game (NEX,...) in PCAP files.
-- Mitm ssl to replace `NintendoClass2CAG3` CA with a user provided one (useful for NPLN traffic capture)
+- Mitm ssl to replace `NintendoClass2CAG3` CA with a user provided one (useful for NPLN traffic capture).
 
 More features might appears depending of the needs.
 
 ## Configuration
-The following configuration should go in `/atmosphere/config/system_settings.ini`:
+The following configuration should be added to `/atmosphere/config/system_settings.ini`:
 
 ```ini
 ; network_mitm config


### PR DESCRIPTION
Confirmed the build from CI - https://github.com/InternalLoss/network_mitm/actions/runs/11440450130 - works on my console and I'm able to capture Splatoon 3 traffic.